### PR TITLE
[ESBCONNECT-139] [ESBCONNECT-138] Set socket properties to connection pools. Fix enabling tracing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
                             <goal>attached</goal>
                         </goals>
                         <configuration>
-                            <finalName>${connector.name}-connector-1.0.0</finalName>
+                            <finalName>${connector.name}-connector-1.0.1</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <filters>
                                 <filter>src/main/assembly/filter.properties</filter>

--- a/src/main/java/org/wso2/carbon/connector/pcml/AS400Initialize.java
+++ b/src/main/java/org/wso2/carbon/connector/pcml/AS400Initialize.java
@@ -78,6 +78,8 @@ public class AS400Initialize extends AbstractConnector {
             AS400ConnectionPool connectionPool = this.getConnectionPool(messageContext, log);
             // If connection pool exist.
             if (null != connectionPool) {
+                connectionPool.setSocketProperties(this.getSocketProperties(messageContext, log));
+
                 log.auditLog("Getting an AS400 connection from connection pool.");
 
                 // Getting the connection from pool.

--- a/src/main/java/org/wso2/carbon/connector/pcml/AS400Trace.java
+++ b/src/main/java/org/wso2/carbon/connector/pcml/AS400Trace.java
@@ -97,6 +97,8 @@ public class AS400Trace extends AbstractConnector {
                 Trace.setTraceProxyOn(Boolean.parseBoolean((String) allLevel));
             }
 
+            Trace.setTraceOn(true);
+
             // Logging for debugging.
             if (log.isTraceOrDebugEnabled()) {
                 log.traceOrDebug("Log level Conversion : " + Trace.isTraceConversionOn());


### PR DESCRIPTION
This PR allows to set socket properties to connection pools and fixes enabling trace logs.

JIRA : 
https://wso2.org/jira/browse/ESBCONNECT-138
https://wso2.org/jira/browse/ESBCONNECT-139