### PR TITLE
Fix connector issues in MI 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.pcml</artifactId>
-    <version>1.0.6</version>
+    <version>2.0.0</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon - PCML Connector For AS400</name>
     <url>http://wso2.org</url>
@@ -192,6 +192,11 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20080701</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.ei</groupId>
+            <artifactId>org.wso2.micro.integrator.registry</artifactId>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.ei</groupId>

--- a/src/main/java/org/wso2/carbon/connector/pcml/AS400CallProgram.java
+++ b/src/main/java/org/wso2/carbon/connector/pcml/AS400CallProgram.java
@@ -32,8 +32,8 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
-import org.wso2.carbon.mediation.registry.WSO2Registry;
-import org.wso2.carbon.registry.core.Resource;
+import org.wso2.micro.integrator.registry.MicroIntegratorRegistry;
+import org.wso2.micro.integrator.registry.Resource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -84,7 +84,7 @@ public class AS400CallProgram extends AbstractConnector {
             String programName = (String) pcmlProgramNameParameter;
 
             // Create program document by getting the PCML file from registry.
-            WSO2Registry registry = (WSO2Registry) messageContext.getConfiguration().getRegistry();
+            MicroIntegratorRegistry registry = (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
             Resource pcmlFileResource = registry.getResource(pcmlFileLocation);
             pcmlFileContent = pcmlFileResource.getContentStream();
 

--- a/src/main/java/org/wso2/carbon/connector/pcml/AS400Utils.java
+++ b/src/main/java/org/wso2/carbon/connector/pcml/AS400Utils.java
@@ -55,8 +55,10 @@ public class AS400Utils {
             AS400PCMLConnectorException {
         List<PCMLInputParam> inputParameters = new ArrayList<>();
         try {
-            String strPCMLObjects = (String) ConnectorUtils.lookupTemplateParamater(messageContext, AS400Constants
-                    .AS400_PCML_PROGRAM_INPUTS);
+            Object pcmlInputsObj = ConnectorUtils.lookupTemplateParamater(messageContext,
+                    AS400Constants.AS400_PCML_PROGRAM_INPUTS);
+            String strPCMLObjects = (pcmlInputsObj instanceof OMElement) ? pcmlInputsObj.toString() :
+                    (String) pcmlInputsObj;
             if (null != strPCMLObjects && !strPCMLObjects.isEmpty()) {
                 OMElement sObjects = AXIOMUtil.stringToOM(strPCMLObjects);
                 if (null != sObjects) {


### PR DESCRIPTION
## Purpose
This PR fixes the following issues with the PCML connector while using with MI 4.1.0.

- Use `MicroIntegratorRegistry` instead of the `WSO2Registry`
- Fix `ClassCastException` while reading `pcmlInputs` value.

Fixes https://github.com/wso2/api-manager/issues/1548

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes